### PR TITLE
Rename Kratos in source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# hive-selfservice-ui-node
+# kratos-selfservice-ui-node
 
-This is an exemplary Self Service UI for ORY Hive's Self Service features:
+This is an exemplary Self Service UI for ORY Kratos's Self Service features:
 
 - Registration
 - Login
@@ -9,11 +9,11 @@ This is an exemplary Self Service UI for ORY Hive's Self Service features:
 
 This application can be configured using two environment variables:
 
-- `HIVE_PUBLIC_URL`: The URL where ORY Hive's public API is located at. If this app and ORY Hive
-    are running in the same private network, this should be the private network address (e.g. `hive-public.svc.cluster.local`).
-- `HIVE_BROWSER_URL`: The URL where ORY Hive's public API is located at, when accessible from the public internet.
-    This could be for example `http://hive.my-app.com/`.
+- `KRATOS_PUBLIC_URL`: The URL where ORY Kratos's public API is located at. If this app and ORY Kratos
+    are running in the same private network, this should be the private network address (e.g. `kratos-public.svc.cluster.local`).
+- `KRATOS_BROWSER_URL`: The URL where ORY Kratos's public API is located at, when accessible from the public internet.
+    This could be for example `http://kratos.my-app.com/`.
 - `BASE_URL`: The base url of this app. If served e.g. behind a proxy or via GitHub pages this would be the path, e.g.
-    `/hive-selfservice-ui-node/`
+    `/kratos-selfservice-ui-node/`
 - `NODE_ENV=only-ui`: If setting environment variable `NODE_ENV` to `only-ui`, then all dependencies on
-    e.g. ORY Hive will be disabled and only the UI will be shown. Useful for developing CSS or HTML.
+    e.g. ORY Kratos will be disabled and only the UI will be shown. Useful for developing CSS or HTML.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hive-selfservice-ui-node",
+  "name": "kratos-selfservice-ui-node",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "hive-selfservice-ui-node",
+  "name": "kratos-selfservice-ui-node",
   "version": "0.0.1",
-  "description": "A reference implementation of a selfservice UI for ORY Hive in node.js",
+  "description": "A reference implementation of a selfservice UI for ORY Kratos in node.js",
   "main": "src/index.ts",
   "scripts": {
     "build": "tsc",
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ory/hive-selfservice-ui-node.git"
+    "url": "git+https://github.com/ory/kratos-selfservice-ui-node.git"
   },
   "author": "Patrik Neu (ORY Corp)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ory/hive-selfservice-ui-node/issues"
+    "url": "https://github.com/ory/kratos-selfservice-ui-node/issues"
   },
-  "homepage": "https://github.com/ory/hive-selfservice-ui-node#readme",
+  "homepage": "https://github.com/ory/kratos-selfservice-ui-node#readme",
   "dependencies": {
     "@types/express": "^4.17.1",
     "@types/express-handlebars": "0.0.33",

--- a/public/index.css
+++ b/public/index.css
@@ -130,12 +130,12 @@ body {
     font-size: 4rem;
 }
 
-.container .hive-errors:not(:empty) {
+.container .kratos-errors:not(:empty) {
     margin-bottom: 1em;
     text-align: left;
 }
 
-.container .hive-errors p {
+.container .kratos-errors p {
     margin: 1em 0;
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,7 +5,7 @@ import fetch from 'node-fetch'
 
 // A simple express handler that shows the login / registration screen.
 // Argument "type" can either be "login" or "registration" and will
-// fetch the form data from ORY Hive's Public API.
+// fetch the form data from ORY Kratos's Public API.
 export const authHandler = (type: 'login' | 'registration') => (
   req: Request,
   res: Response,
@@ -17,19 +17,19 @@ export const authHandler = (type: 'login' | 'registration') => (
   // return data like the csrf_token and so on.
   if (!request) {
     console.log('No request found in URL, initializing auth flow.')
-    res.redirect(`${config.hive.browser}/auth/browser/${type}`)
+    res.redirect(`${config.kratos.browser}/auth/browser/${type}`)
     return
   }
 
-  // This is the ORY Hive URL. If this app and ORY Hive are running
-  // on the same (e.g. Kubernetes) cluster, this should be ORY Hive's internal hostname.
-  const url = new URL(`${config.hive.public}/auth/browser/requests/${type}`)
+  // This is the ORY Kratos URL. If this app and ORY Kratos are running
+  // on the same (e.g. Kubernetes) cluster, this should be ORY Kratos's internal hostname.
+  const url = new URL(`${config.kratos.public}/auth/browser/requests/${type}`)
   url.searchParams.set('request', request)
 
   fetch(url.toString())
     .then(response => {
       if (response.status == 404) {
-        res.redirect(`${config.hive.browser}/auth/browser/${type}`)
+        res.redirect(`${config.kratos.browser}/auth/browser/${type}`)
         return
       }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,11 @@
 export default {
-    hive: {
+    kratos: {
         browser: (
-            process.env.HIVE_BROWSER_URL ||
-            process.env.HIVE_PUBLIC_URL ||
+            process.env.KRATOS_BROWSER_URL ||
+            process.env.KRATOS_PUBLIC_URL ||
             ''
         ).replace(/\/+$/, ''),
-        public: (process.env.HIVE_PUBLIC_URL || '').replace(/\/+$/, ''),
+        public: (process.env.KRATOS_PUBLIC_URL || '').replace(/\/+$/, ''),
     },
     baseUrl: (process.env.BASE_URL || '/').replace(/\/+$/, '') + '/',
     jwksUrl: process.env.JWKS_URL || '/',

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -43,6 +43,6 @@ ${interestingHeaders
   )
   .join('\n')}
 ...`,
-    logoutUrl: `${config.hive.browser}/auth/browser/logout`,
+    logoutUrl: `${config.kratos.browser}/auth/browser/logout`,
   })
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,9 +12,9 @@ export default (req: Request, res: Response, next: NextFunction) => {
     return
   }
 
-  // This is the ORY Hive URL. If this app and ORY Hive are running
-  // on the same (e.g. Kubernetes) cluster, this should be ORY Hive's internal hostname.
-  const url = new URL(`${config.hive.public}/errors`)
+  // This is the ORY Kratos URL. If this app and ORY Kratos are running
+  // on the same (e.g. Kubernetes) cluster, this should be ORY Kratos's internal hostname.
+  const url = new URL(`${config.kratos.public}/errors`)
   url.searchParams.set('error', error)
 
   fetch(url.toString())

--- a/views/login.hbs
+++ b/views/login.hbs
@@ -3,7 +3,7 @@
         <h1>{{projectName}}</h1>
         <h2>Log in</h2>
 
-        <div class="hive-errors">
+        <div class="kratos-errors">
             {{#each errors}}
                 <p>{{ message }}</p>
             {{/each}}

--- a/views/registration.hbs
+++ b/views/registration.hbs
@@ -3,7 +3,7 @@
         <h1>{{projectName}}</h1>
         <h2>Sign up</h2>
 
-        <div class="hive-errors">
+        <div class="kratos-errors">
             {{#each errors}}
                 <p>{{ message }}</p>
             {{/each}}


### PR DESCRIPTION
It seems this repo's name was `hive-selfservice-ui-node` and renamed `kratos-selfservice-ui-node` but source code is still old name.
I confused because I didn't know what Hive means.