### PR TITLE
improvement: Implement a version without OathKeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ If you intend to run this app with ORY Kratos, the easiest way is to use the ORY
 
 This application can be configured using two environment variables:
 
-- `JWKS_URL` - The URL to be used to check if the signature of the incoming ID token is valid.
 - `KRATOS_ADMIN_URL`: The URL where ORY Kratos's Admin API is located at. If this app and ORY Kratos
     are running in the same private network, this should be the private network address (e.g. `kratos-admin.svc.cluster.local`).
 - `KRATOS_PUBLIC_URL`: The URL where ORY Kratos's Public API is located at. If this app and ORY Kratos
@@ -38,5 +37,16 @@ This application can be configured using two environment variables:
     This could be for example `http://kratos.my-app.com/`.
 - `BASE_URL`: The base url of this app. If served e.g. behind a proxy or via GitHub pages this would be the path, e.g.
     `/kratos-selfservice-ui-node/`
+
+### With Oathkeeper (JWT)
+
+- `JWKS_URL`: The URL to be used to check if the signature of the incoming ID token is valid.
+
+### Without Oathkeeper (Cookie)
+
+- `KRATOS_WITH_OATHKEEPER`: This flag indicates that this app is used without Oathkeeper. In that case, the server proxies directly Kratos public API. `KRATOS_BROWSER_URL` have to be set to this application base URL.
+
+### Front development
+
 - `NODE_ENV=only-ui`: If setting environment variable `NODE_ENV` to `only-ui`, then all dependencies on
     e.g. ORY Kratos will be disabled and only the UI will be shown. Useful for developing CSS or HTML.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This application can be configured using two environment variables:
 
 - `JWKS_URL`: The URL to be used to check if the signature of the incoming ID token is valid.
 
-### Without Oathkeeper (Cookie)
+### Standalone (Cookie)
 
-- `KRATOS_WITH_OATHKEEPER`: This flag indicates that this app is used without Oathkeeper. In that case, the server proxies directly Kratos public API. `KRATOS_BROWSER_URL` have to be set to this application base URL.
+- `SECURITY_MODE`: If this is set to `COOKIE`, then this app is used without Oathkeeper and rely on cookies (default value is `JWT`). In that case, the ExpressJS server proxies Kratos public API under `/self-service/`.
 
 ### Front development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,6 +618,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,11 +179,11 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -254,9 +254,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -918,14 +918,14 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "filewatcher": {
       "version": "3.0.1",
@@ -1936,9 +1936,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -2011,9 +2011,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2022,7 +2022,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -2032,7 +2032,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -2317,19 +2317,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tree-kill": {
@@ -2458,9 +2451,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jwt-decode": "^2.2.0",
     "morgan": "^1.9.1",
     "node-fetch": "^2.6.0",
+    "request": "^2.88.2",
     "typescript": "^3.7.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/morgan": "^1.7.37",
     "@types/node": "^12.12.27",
     "@types/node-fetch": "^2.5.4",
+    "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",
     "express-jwt": "^5.3.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,9 @@ export default {
     admin: (process.env.KRATOS_ADMIN_URL || '').replace(/\/+$/, ''),
     public: (process.env.KRATOS_PUBLIC_URL || '').replace(/\/+$/, ''),
   },
+
   baseUrl: (process.env.BASE_URL || '/').replace(/\/+$/, '') + '/',
   jwksUrl: process.env.JWKS_URL || '/',
+  withOathkeeper: parseInt(process.env.KRATOS_WITH_OATHKEEPER || '1'),
   projectName: process.env.PROJECT_NAME || 'SecureApp',
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,8 @@ export default {
     admin: (process.env.KRATOS_ADMIN_URL || '').replace(/\/+$/, ''),
     public: (process.env.KRATOS_PUBLIC_URL || '').replace(/\/+$/, ''),
   },
-
   baseUrl: (process.env.BASE_URL || '/').replace(/\/+$/, '') + '/',
   jwksUrl: process.env.JWKS_URL || '/',
-  withOathkeeper: parseInt(process.env.KRATOS_WITH_OATHKEEPER || '1'),
+  securityMode: process.env.SECURITY_MODE || 'JWT',
   projectName: process.env.PROJECT_NAME || 'SecureApp',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const protectProxy = (req: Request, res: Response, next: NextFunction) => {
   res.redirect('/auth/login')
 }
 
-const protect = config.kratos.browser ? protectOathKeeper : protectProxy
+const protect = config.withOathkeeper ? protectOathKeeper : protectProxy
 
 const app = express()
 app.use(morgan('tiny'))
@@ -109,7 +109,7 @@ if (process.env.NODE_ENV === 'only-ui') {
 app.get('/health', (_: Request, res: Response) => res.send('ok'))
 app.get('/debug', debug)
 
-if (!config.kratos.browser) {
+if (!config.withOathkeeper) { // ExpressJS proxies Kratos public API
   app.use('/self-service', function(req: Request, res: Response) {
     const url = config.kratos.public + '/self-service' + req.url
     req.pipe(request(url, { followRedirect: false })).pipe(res)

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5,22 +5,24 @@ import jd from 'jwt-decode'
 type UserRequest = Request & { user: any }
 
 const authInfo = (req: UserRequest) => {
-  const bearer = req.header('authorization')
-  if (bearer) {
-    // The header will be in format of `Bearer eyJhbGci...`. We therefore split at the whitespace to get the token
-    // itself only.
-    let token = bearer.split(' ')[1]
-    return {
-      raw: token,
-      claims: req.user,
+  if (config.withOathkeeper) {
+    const bearer = req.header('authorization')
+    if (bearer) {
+      // The header will be in format of `Bearer eyJhbGci...`. We therefore split at the whitespace to get the token
+      // itself only.
+      let token = bearer.split(' ')[1]
+      return {
+        raw: token,
+        claims: req.user,
+      }
     }
-  }
-
-  const session = req.cookies.ory_kratos_session
-  if (session) {
-    return {
-      raw: session,
-      claims: req.user,
+  } else {
+    const session = req.cookies.ory_kratos_session
+    if (session) {
+      return {
+        raw: session,
+        claims: req.user,
+      }
     }
   }
 

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5,7 +5,7 @@ import jd from 'jwt-decode'
 type UserRequest = Request & { user: any }
 
 const authInfo = (req: UserRequest) => {
-  if (config.withOathkeeper) {
+  if (config.securityMode === 'JWT') {
     const bearer = req.header('authorization')
     if (bearer) {
       // The header will be in format of `Bearer eyJhbGci...`. We therefore split at the whitespace to get the token

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -16,6 +16,14 @@ const authInfo = (req: UserRequest) => {
     }
   }
 
+  const session = req.cookies.ory_kratos_session
+  if (session) {
+    return {
+      raw: session,
+      claims: req.user,
+    }
+  }
+
   // In the demo mode, the token will not be available in the header. Instead, we'll use this example token:
   const token =
     'eyJhbGciOiJSUzI1NiIsImtpZCI6ImEyYWE5NzM5LWQ3NTMtNGEwZC04N2VlLTYxZjEwMTA1MDI3NyIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzg5MjU0MTMsImlhdCI6MTU3ODkyNTM1MywiaXNzIjoiaHR0cDovLzEyNy4wLjAuMTo0NDU1LyIsImp0aSI6ImM3NDhjYzc4LTJlOTAtNGVhNi1iNTdmLTA3YmI4YjNlNGUxYyIsIm5iZiI6MTU3ODkyNTM1Mywic2Vzc2lvbiI6eyJhdXRoZW50aWNhdGVkX2F0IjoiMDAwMS0wMS0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyMC0wMS0wOVQxOTozMDoxMC43MzM4NDRaIiwiaWRlbnRpdHkiOnsiaWQiOiJlM2IxZmM2MS0wMjMxLTQwODMtYjQ3MC0yODkwMDE2ZmY5ZmUiLCJ0cmFpdHMiOnsiZW1haWwiOiJoaWxhZnNkaG9pdWFmZHNAYXNkZi5kZSJ9LCJ0cmFpdHNfc2NoZW1hX3VybCI6ImZpbGU6Ly8vZXRjL2NvbmZpZy9rcmF0b3MvaWRlbnRpdHkudHJhaXRzLnNjaGVtYS5qc29uIn0sImlzc3VlZF9hdCI6IjIwMjAtMDEtMDlUMTg6MzA6MTAuNzMzOTMwNVoiLCJzaWQiOiI5NWQwMWNkYy1kMGY2LTQ1Y2MtODdlYi02NTA1ZTRkYTlkNTcifSwic3ViIjoiZTNiMWZjNjEtMDIzMS00MDgzLWI0NzAtMjg5MDAxNmZmOWZlIn0.JZVmc-EG-1k5RB7W4mouU6ycrRVJPimNUZXL59fwnIWKokhzV0itgYXm4eFV5VDYSt5S7VQgK7PmJFqYaaLtdz1yqqACH4E19VSanwB57mKCawePSvHIYnCnQW0E8vr9RavQPeluMfDS239FMow7-kq1ydkKVryhImfllW2pmAXC-0K9_0BE584u4RV7Ki0rGG2xhb8DelHpHurXStFRzi2BDW_J5xn1zlb9QyYEThX17KnXRJZkJpmTUgUBPGfUHSL6-267YgkIGKzVgCQ0dBFfAX4vDqL4qthNP3K9iS404jXLSrwYvTN6Y_xI-B-WCSqXX3PGBTnMgKB5pCsiPA'


### PR DESCRIPTION
I struggled a lot with the full appropriate setup (without Docker). At the beginning I refused to rely on OathKeeper but I had too much trouble with invalid CSRF cookies.

I kicked ouf OathKeeper and get everything to work.
I thought it was worth giving a try to an implementation (simplification) without OathKeeper.

This proxies Kratos public API at /self-service which sound enough for an exemplary Self Service UI.

Related to https://github.com/ory/kratos/issues/262.
