### PR TITLE
fix: Fix 'jwt' compare bug in dashboard.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,4 +29,6 @@ export default {
   projectName: process.env.PROJECT_NAME || 'SecureApp',
 
   securityMode,
+  SECURITY_MODE_JWT,
+  SECURITY_MODE_STANDALONE,
 }

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -5,7 +5,7 @@ import jd from 'jwt-decode'
 type UserRequest = Request & { user: any }
 
 const authInfo = (req: UserRequest) => {
-  if (config.securityMode === 'JWT') {
+  if (config.securityMode === config.SECURITY_MODE_JWT) {
     const bearer = req.header('authorization')
     if (bearer) {
       // The header will be in format of `Bearer eyJhbGci...`. We therefore split at the whitespace to get the token


### PR DESCRIPTION
## Related issue

https://github.com/ory/kratos-selfservice-ui-node/issues/58

## Proposed changes

in `dashboard.ts`
```
if (config.securityMode === config.SECURITY_MODE_JWT) {
```

in `config.ts`
```
  securityMode,
  SECURITY_MODE_JWT,
  SECURITY_MODE_STANDALONE,
```


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
