### PR TITLE
fix: redirect loop while trying to get /session/whoami on domain-bas…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const protectProxy = (req: Request, res: Response, next: NextFunction) => {
   // When using ORY Oathkeeper, the redirection is done by ORY Oathkeeper.
   // Since we're checking for the session ourselves here, we redirect here
   // if the session is invalid.
+  req.headers['host'] = config.kratos.public.split('/')[2]
   publicEndpoint
     .whoami(req as { headers: { [name: string]: string } })
     .then(({ body, response }) => {


### PR DESCRIPTION
Fixes #60 
Split preserves port if it was set in config.kratos.public - so it's okay.