### PR TITLE
fix: redirect issues for hydra integration in domain (not port) based env

### DIFF
--- a/src/routes/hydra.ts
+++ b/src/routes/hydra.ts
@@ -145,6 +145,7 @@ export const hydraLogin = (req: Request, res: Response, next: NextFunction) => {
       }
 
       // Figuring out the user
+      req.headers['host'] = config.kratos.public.split('/')[2]
       return (
         kratosClient
           // We need to know who the user is for hydra

--- a/src/routes/hydra.ts
+++ b/src/routes/hydra.ts
@@ -11,7 +11,7 @@ import { isString } from '../helpers'
 import crypto from 'crypto'
 
 // Client for interacting with Hydra's Admin API
-const hydraClient = new HydraAdminApi(process.env.HYDRA_ADMIN_URL)
+const hydraClient = new HydraAdminApi(config.hydra.admin)
 
 // Client for interacting with Kratos' Public and Admin API
 const kratosClient = new PublicApi(config.kratos.public)


### PR DESCRIPTION
## Related issue

#67 

## Proposed changes

1. Replace 'host' header while communicating with kratos to prevent reverse-proxy misbehaviour - see #60 . Fixes 302 redirect error with Traefik. Probably with nginx there will be another error: the wrong host will respond to http query. Therefore response will obviously have unexpected content.
2. Make code read Hydra URL from config instead of reading from env var directly. As as side effect it removes trailing slash which fixes 307 redirect error while communicating with Hydra (either in domain-based env or I just have env vars misconfigured - I don't know and it dows not matter because anyway there is no need to read anything from env when we do already have everything in config)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
