### PR TITLE
fix: case where BASE_URL is empty

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import urljoin from 'url-join'
 export const SECURITY_MODE_STANDALONE = 'cookie'
 export const SECURITY_MODE_JWT = 'jwt'
 
-const baseUrl = process.env.BASE_URL || ''
+const baseUrl = process.env.BASE_URL || '/'
 
 let securityMode = SECURITY_MODE_JWT
 let browserUrl = process.env.KRATOS_BROWSER_URL || ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,10 @@ if (config.securityMode === SECURITY_MODE_STANDALONE) {
   app.use(
     '/.ory/kratos/public/',
     (req: Request, res: Response, next: NextFunction) => {
-      const url =
-        urljoin(config.kratos.public, req.url.replace('/.ory/kratos/public', ''))
+      const url = urljoin(
+        config.kratos.public,
+        req.url.replace('/.ory/kratos/public', '')
+      )
       req
         .pipe(request(url, { followRedirect: false }).on('error', next))
         .pipe(res)

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ app.set('view engine', 'hbs')
 
 app.use((req: Request, res: Response, next: NextFunction) => {
   res.locals.projectName = config.projectName
-  res.locals.baseUrl = urljoin(config.baseUrl, '/')
+  res.locals.baseUrl = config.baseUrl
   res.locals.pathPrefix = config.baseUrl ? '' : '/'
   next()
 })
@@ -129,7 +129,7 @@ if (config.securityMode === SECURITY_MODE_STANDALONE) {
     '/.ory/kratos/public/',
     (req: Request, res: Response, next: NextFunction) => {
       const url =
-        config.kratos.public + req.url.replace('/.ory/kratos/public', '')
+        urljoin(config.kratos.public, req.url.replace('/.ory/kratos/public', ''))
       req
         .pipe(request(url, { followRedirect: false }).on('error', next))
         .pipe(res)


### PR DESCRIPTION
## Related issue

`urljoin` introduced with #70 actually behaves differently than expected:
```js
urljoin('', '/some-path')
// gives 'some-path'
```