### PR TITLE
docs: adds missing KRATOS_BROWSER_URL env var and corrects which container to kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ running. This is what that would look like:
 ```shell script
 # start the quickstart using docker compose as explained in the tutorial: https://www.ory.sh/kratos/docs/quickstart/
 export SECURITY_MODE=cookie
+export KRATOS_BROWSER_URL=http://127.0.0.1:4433/
 export KRATOS_PUBLIC_URL=http://127.0.0.1:4433/
 export KRATOS_ADMIN_URL=http://127.0.0.1:4434/
 export PORT=4455
@@ -102,7 +103,7 @@ export PORT=4455
 # 
 # Next you need to kill the docker container that runs this app in order to free the ports:
 #
-#   docker kill kratos_oathkeeper_1
+#   docker kill kratos_kratos-selfservice-ui-node_1
 
 npm start
 ```


### PR DESCRIPTION
## Proposed changes

* Add the KRATOS_BROWSER_URL environment variable in the quickstart to make the ui work in development mode. Without the variable the ui tries to redirect to the kratos path but on the same site which leads to an endless redirect loop.
* Corrects the container to kill to be able to start the development ui 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation within the code base (if appropriate)