### PR TITLE
chore: update repository template to 5c66cd06

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY Community
-    url: https://community.ory.sh/
-    about: Please ask and answer questions here.
+  - name: ORY Kratos SelfService UI Node Example Forum
+    url: https://www.github.com/{{Repo}}/discussions
+    about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: ORY Chat
     url: https://www.ory.sh/chat
     about: Hang out with other ORY community members and ask and answer questions.
-  - name: ORY Enterprise Contact
-    url: https://www.ory.sh/contact
-    about: Jared will help you with your enterprise-related inquiries.
+  - name: ORY Support for Business
+    url: https://github.com/ory/open-source-support/blob/master/README.md
+    about: Buy professional support for ORY Kratos SelfService UI Node Example .

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`)
 If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
 chance substantial changes will be requested or that the changes will be rejected.
 
-You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
+You can discuss changes with maintainers either in the Github Discusssions in this repository or
 join the [ORY Chat](https://www.ory.sh/chat).
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by ORY Kratos SelfService UI Node Example's normal direction. A great way to
-do this is via the [ORY Community](https://community.ory.sh/) or join the
-[ORY Chat](https://www.ory.sh/chat).
+do this is via
+[ORY Kratos SelfService UI Node Example Discussions](https://github.com/ory/Kratos SelfService UI Node Example/discussions) or
+the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
@@ -110,8 +111,10 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-We have a [forum](https://community.ory.sh/). This is a great place for in-depth
-discussions and lots of code examples, logs and similar data.
+Check out
+[ORY Kratos SelfService UI Node Example Discussions](https://github.com/ory/Kratos SelfService UI Node Example/discussions).
+This is a great place for in-depth discussions and lots of code examples, logs
+and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/5c66cd0662b16ad195beaf72d8a892af20eb8e9d.