### PR TITLE
fix: do not run as root in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /usr/src/app
 
 ARG LINK=no
 
+RUN adduser -S ory -D -u 10000 -s /bin/nologin
+
 COPY package.json .
 COPY package-lock.json .
 
@@ -17,6 +19,8 @@ RUN if [ "$LINK" == "true" ]; then (cd ./contrib/sdk/generated; rm -rf node_modu
     fi
 
 RUN npm run build
+
+USER 10000
 
 ENTRYPOINT npm run serve
 


### PR DESCRIPTION
## Related PR

* https://github.com/ory/hydra-login-consent-node/pull/91

## Proposed changes

As described in the linked PR for security reasons we should not run processes inside Docker container as root. This should allow us run this image safely on kubernetes with elevated Pod Security Policies. Since this is an example service not to meant to be run on production environment it is not a real security concern.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).