### PR TITLE
fix: Properly build pathPrefix variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import recoveryHandler from './routes/recovery'
 import morgan from 'morgan'
 import * as https from 'https'
 import * as fs from 'fs'
-import * as path from 'path'
 import protectSimple from './middleware/simple'
 import protectOathkeeper from './middleware/oathkeeper'
 
@@ -30,7 +29,7 @@ app.set('view engine', 'hbs')
 app.use((req: Request, res: Response, next: NextFunction) => {
   res.locals.projectName = config.projectName
   res.locals.baseUrl = config.baseUrl
-  res.locals.pathPrefix = path.join(config.baseUrl, './')
+  res.locals.pathPrefix = config.baseUrl.replace(/\/+$/, '') + '/'
   next()
 })
 


### PR DESCRIPTION
## Related issue

Fixes issue introduced in #120.

## Proposed changes

`path.join()` does not work well with fully qualified URLs producing: `https:/example.com` instead of `https://example.com`.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
