### PR TITLE
feat: separate internal and browser url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This application can be configured using two environment variables:
   be the private network address (e.g. `kratos-public.svc.cluster.local`).
 - `TLS_CERT_PATH` (optional): Path to certificate file. Should be set up together with `TLS_KEY_PATH` to enable HTTPS.
 - `TLS_KEY_PATH` (optional): Path to key file Should be set up together with `TLS_CERT_PATH` to enable HTTPS.
+- `KRATOS_BROWSER_URL` (optional) The browser accessible URL where ORY Kratos's public API is located, only needed if it differs from `KRATOS_PUBLIC_URL`
 
 This is the easiest mode as it requires no additional set up. This app runs on port `:4455`
 and ORY Kratos `KRATOS_PUBLIC_URL` URL.

--- a/src/pkg/sdk/index.ts
+++ b/src/pkg/sdk/index.ts
@@ -4,19 +4,23 @@ import {
   V0alpha2ApiInterface
 } from '@ory/kratos-client'
 
-export const apiBaseUrl =
+const apiBaseUrlInternal =
   process.env.KRATOS_PUBLIC_URL ||
   process.env.ORY_SDK_URL ||
   'https://playground.projects.oryapis.com'
 
+export const apiBaseUrl = process.env.KRATOS_BROWSER_URL || apiBaseUrlInternal
+
 // Sets up the SDK using Ory Cloud
 let sdk: V0alpha2ApiInterface = new V0alpha2Api(
-  new Configuration({ basePath: apiBaseUrl })
+  new Configuration({ basePath: apiBaseUrlInternal })
 ) as unknown as V0alpha2ApiInterface
 
 // Alternatively use the Ory Kratos SDK.
 if (process.env.KRATOS_PUBLIC_URL) {
-  sdk = new OpenSourceV0alpha2Api(new Configuration({ basePath: apiBaseUrl }))
+  sdk = new OpenSourceV0alpha2Api(
+    new Configuration({ basePath: apiBaseUrlInternal })
+  )
 }
 
 export default sdk


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
Would like to have self-service use internal URL to reach kratos, e.g `kratos.svc.cluster.local`
But browser cannot reach that url, so we need to separate those url's.
I've tested this in kubernetes with open source kratos, and it seems to work nice.

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
