### PR TITLE
docs: add KRATOS_ADMIN_URL env variable and fix HYDRA_ADMIN_URL mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ Ory Identities requires the following variables to be set:
   `kratos-public.svc.cluster.local`).
 - `KRATOS_BROWSER_URL` (optional) The browser accessible URL where ORY Kratos's
   public API is located, only needed if it differs from `KRATOS_PUBLIC_URL`
+- `KRATOS_ADMIN_URL` (optional) The URL where Ory Kratos' Admin API is located
+  at (e.g. `http://kratos:4434`).
 
 Ory OAuth2 requires more setup to get CSRF cookies on the `/consent` endpoint.
 
-- `ORY_SDK_URL` or `HYDRA_ADMIN_URL` (optional): The URL where Ory Hydra's
-  Public API is located at. If this app and Ory Hydra are running in the same
-  private network, this should be the private network address (e.g.
+- `ORY_SDK_URL` or `HYDRA_ADMIN_URL` (optional): The URL where Ory Hydra's Admin
+  API is located at. If this app and Ory Hydra are running in the same private
+  network, this should be the private network address (e.g.
   `hydra-admin.svc.cluster.local`)
 - `COOKIE_SECRET` (required): Required for signing cookies. Must be a string
   with at least 8 alphanumerical characters.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Add more documentation for Hydra consent flow integration.