### PR TITLE
feat: propagate arbitrary identity traits into consent session tokens

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,18 +4,11 @@ on:
   pull_request:
   push:
 
-env:
-  CGO_ENABLED: "0"
-
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
-        with:
-          check-latest: true
-          go-version-file: go.mod
       - run: make format
       - name: Indicate formatting issues
         run: git diff HEAD --exit-code --color

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Ory OAuth2 requires more setup to get CSRF cookies on the `/consent` endpoint.
   name without the `__Host-` prefix.
 - `TRUSTED_CLIENT_IDS` (optional): A list of trusted client ids. They can be set
   to skip the consent screen.
+- `SESSION_EXTRA_TRAITS_ID_TOKEN` (optional): Comma-separated list of Kratos
+  identity trait names to propagate verbatim into `session.id_token` during the
+  OAuth2 consent flow. Any trait present on `identity.traits` under one of the
+  listed names is copied to the ID token; missing traits are skipped. Useful
+  when downstream apps rely on identity attributes that aren't part of the
+  built-in `email` / `profile` claim mapping (e.g. `groups`, `department`,
+  `tenant_id`). Example: `SESSION_EXTRA_TRAITS_ID_TOKEN=groups,department`.
+- `SESSION_EXTRA_TRAITS_ACCESS_TOKEN` (optional): Same as above but for
+  `session.access_token`. Set both if the trait needs to be readable from both
+  tokens.
 
 Getting TLS working:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Ory OAuth2 requires more setup to get CSRF cookies on the `/consent` endpoint.
   `session.access_token`. Set both if the trait needs to be readable from both
   tokens.
 
+  **Note:** unlike the built-in `email` / `profile` claims (which are only added
+  when the OIDC client requests the corresponding scope), traits listed in these
+  env vars are propagated unconditionally into every issued token, regardless of
+  which scopes the client asked for. Only enable this when the trait should
+  always be present and its exposure to any OIDC client of this UI is
+  acceptable.
+
 Getting TLS working:
 
 - `TLS_CERT_PATH` (optional): Path to certificate file. Should be set up

--- a/src/routes/consent.ts
+++ b/src/routes/consent.ts
@@ -12,6 +12,27 @@ import { AcceptOAuth2ConsentRequestSession } from "@ory/client"
 import { UserConsentCard } from "@ory/elements-markup"
 import { Request, Response, NextFunction } from "express"
 
+// Parses a comma-separated env var into a list of trait names to propagate
+// from `identity.traits` into the corresponding session token map.
+const parseTraitList = (raw: string | undefined): string[] =>
+  (raw || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+
+const copyTraitsInto = (
+  target: Record<string, unknown>,
+  traits: Record<string, unknown> | undefined,
+  names: string[],
+): void => {
+  if (!traits) return
+  for (const name of names) {
+    if (Object.prototype.hasOwnProperty.call(traits, name)) {
+      target[name] = traits[name]
+    }
+  }
+}
+
 const extractSession = (
   req: Request,
   grantScope: string[],
@@ -63,6 +84,22 @@ const extractSession = (
       )
     }
   }
+
+  // Propagate additional identity traits into the session tokens, based on
+  // operator-provided allowlists. Applied unconditionally (no scope gate) so
+  // downstream apps get the trait even when the OIDC client requested only
+  // openid. Missing traits are skipped silently.
+  copyTraitsInto(
+    session.id_token as Record<string, unknown>,
+    identity.traits as Record<string, unknown> | undefined,
+    parseTraitList(process.env.SESSION_EXTRA_TRAITS_ID_TOKEN),
+  )
+  copyTraitsInto(
+    session.access_token as Record<string, unknown>,
+    identity.traits as Record<string, unknown> | undefined,
+    parseTraitList(process.env.SESSION_EXTRA_TRAITS_ACCESS_TOKEN),
+  )
+
   return session
 }
 


### PR DESCRIPTION
### Problem

`extractSession` in `src/routes/consent.ts` hardcodes which Kratos identity attributes are propagated into the Hydra consent session: `email` (from `verifiable_addresses[0]`) and a handful of `profile` claims (`preferred_username`, `website`, `given_name`, `family_name`, `name`, `updated_at`). Any other trait defined on the identity is silently dropped when Hydra issues the ID / access token.

This bites deployments that store custom traits on the Kratos identity and want them in the JWT for downstream authorization. For example: `groups` extracted from a SAML assertion (via Polis or another SAML-to-OIDC bridge) or upstream OIDC `groups` claim, `department`, `tenant_id`, etc.

Today the only workarounds are to fork the UI or to patch `consent.js` in place at pod startup, both of which break on any upstream refactor.

### Change

Adds two optional env vars:

- `SESSION_EXTRA_TRAITS_ID_TOKEN`: comma-separated list of trait names to copy from `identity.traits` into `session.id_token`.
- `SESSION_EXTRA_TRAITS_ACCESS_TOKEN`: same, for `session.access_token`.

Missing traits are skipped silently. Copying is unconditional on OIDC scope (customers who want a `groups` claim without also granting the `profile` scope shouldn't have to). Values are copied verbatim, so array / string / object shapes all flow through as-is.

### Example

Kratos identity schema declares a `groups` trait; the OIDC mapper populates it from the upstream provider. Setting

```
SESSION_EXTRA_TRAITS_ID_TOKEN=groups
```

on the UI pod gets `"groups": ["engineering", "admins"]` into every issued ID token. Downstream apps consume the claim like any other JWT field.

### Alternatives considered

- **jsonnet-style mapping** (mirroring Kratos's OIDC mapper): more powerful (rename, transform, filter) but higher lift and duplicates config surface that Kratos already exposes.
- **Webhook** at consent time: most flexible but a much bigger design change.

Env-driven allowlist is the smallest change that covers the "just include this trait" case.

### Test plan

- [x] `tsc --noEmit` passes
- [x] `prettier --check` clean
- Manual: deploy patched image with `SESSION_EXTRA_TRAITS_ID_TOKEN=groups`, confirm `groups` appears in the ID token issued via a Hydra OAuth2 authorization code flow.
- No existing test infra in this repo (`"test": "exit 0"`), otherwise happy to add cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consent sessions can now include additional identity trait values in issued token payloads when explicitly configured via environment variables.
  * Only allowlisted trait names are copied, and missing optional traits are ignored; the configured traits are included in every issued token regardless of requested OIDC scopes.

* **Documentation**
  * Updated Configuration docs to describe the new optional environment variables and how to provide a comma-separated trait allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->